### PR TITLE
Add integral reporting counters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
 
         ext.sourceCompatibility = JavaVersion.VERSION_1_6
 
-        version = '83.0-Tfly'
+        version = '84.0-Tfly'
 
         group = "com.ticketfly"
 
@@ -41,7 +41,7 @@ subprojects {
 
 	task publishDocs(type: Copy, dependsOn: "javadoc") {
 		from 'build/docs'
-		into '../../ticketfly.github.com/docs/pillage-core/82.0-Tfly'
+		into '../../ticketfly.github.com/docs/pillage-core/84.0-Tfly'
 	}
 
 	repositories {

--- a/pillage-core/src/main/java/com/ticketfly/pillage/AsyncStatsContainer.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/AsyncStatsContainer.java
@@ -47,6 +47,10 @@ public class AsyncStatsContainer implements StatsContainer {
 					  IncCounter c = (IncCounter) command;
 					  container.incr(c.name, c.value);
 				  }
+				  else if ( command instanceof IncrementIntegralCounter ){
+					  IncrementIntegralCounter c = (IncrementIntegralCounter) command;
+					  container.incrementIntegral(c.name, c.value);
+				  }
 				  else if ( command instanceof ClearCounter ){
 					  ClearCounter c = (ClearCounter) command;
 					  container.clearCounter(c.name);
@@ -114,6 +118,15 @@ public class AsyncStatsContainer implements StatsContainer {
 			this.value = value;
 		}
 	}
+
+    private static class IncrementIntegralCounter implements StatsCommand {
+        final public String name;
+        final public int value;
+        IncrementIntegralCounter(String name, int value){
+            this.name = name;
+            this.value = value;
+        }
+    }
 	
 	private static class ClearCounter implements StatsCommand{
 	    final public String name;
@@ -153,6 +166,11 @@ public class AsyncStatsContainer implements StatsContainer {
 		queue.offer(new IncCounter(name, count));
 
 	}
+    
+    @Override
+    public void incrementIntegral(String name, int count) {
+       queue.offer(new IncrementIntegralCounter(name, count));
+    }
 
 	@Override
 	public void incr(String name) {
@@ -179,9 +197,14 @@ public class AsyncStatsContainer implements StatsContainer {
 		queue.offer( new ClearCounter(name) );
 	}
 
+    @Override
+    public Counter getCounter(String name) {
+            return container.getCounter(name);
+    }
+
 	@Override
-	public Counter getCounter(String name) {
-		return container.getCounter(name);
+	public Counter getCounter(String name, ReportingMode mode) {
+		return container.getCounter(name, mode);
 	}
 
 	@Override
@@ -204,7 +227,12 @@ public class AsyncStatsContainer implements StatsContainer {
 		return container.counters();
 	}
 
-	@Override
+    @Override
+    public Map<String, ReportingInstance> getReportingInstances() {
+        return container.getReportingInstances();
+    }
+
+    @Override
 	public Map<String, Distribution> metrics() {
 		return container.metrics();
 	}

--- a/pillage-core/src/main/java/com/ticketfly/pillage/Counter.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/Counter.java
@@ -25,13 +25,20 @@ public class Counter {
 
     private AtomicLong counter = new AtomicLong(0L);
 
+    private ReportingMode reportingMode = ReportingMode.DIFFERENTIAL;
+
     public long incr(){  return counter.incrementAndGet(); }
     public long incr( int i ){ return counter.addAndGet(i); }
     public long value(){ return counter.get(); }
     public void update(long l){ counter.set(l); }
     public void reset() { counter.set(0); }
+    public void setReportingMode(ReportingMode mode) { reportingMode = mode; }
+    public ReportingMode getReportingMode() { return reportingMode; }
 
     @Override
     public String toString() { return "Counter[" + counter.get() + "]"; }
-
+    
+    public Counter(ReportingMode mode) {
+        reportingMode = mode;
+    }
 }

--- a/pillage-core/src/main/java/com/ticketfly/pillage/GraphiteStatsReporter.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/GraphiteStatsReporter.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/pillage-core/src/main/java/com/ticketfly/pillage/ReportingInstance.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/ReportingInstance.java
@@ -1,0 +1,14 @@
+package com.ticketfly.pillage;
+
+/**
+ * ReportingInstance.java
+ * Define the equivalent of a case class to transport count data for reporting
+ */
+public class ReportingInstance {
+    public long count;
+    public ReportingMode mode;
+    ReportingInstance(long c, ReportingMode m) {
+        count = c;
+        mode = m;
+    }
+}

--- a/pillage-core/src/main/java/com/ticketfly/pillage/ReportingMode.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/ReportingMode.java
@@ -1,0 +1,10 @@
+package com.ticketfly.pillage;
+
+/**
+ * ReportingMode.java
+ * Define differences in the ways counter and metric information can be reported.
+ */
+public enum ReportingMode {
+    DIFFERENTIAL, /* Send diffs of counter from last snapshot, to graphite and the other reporters. */
+    INTEGRAL /* don't calculate deltas in triggerCounterSnap, etc, just return whole value to graphite */
+}

--- a/pillage-core/src/main/java/com/ticketfly/pillage/StatsCollectorImpl.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/StatsCollectorImpl.java
@@ -161,14 +161,20 @@ public class StatsCollectorImpl implements StatsCollector {
         Map<String, Long> deltas = new HashMap<String, Long>();
         synchronized (this) {
 
-            for (Map.Entry<String, Long> entry : container.counters().entrySet()) {
+            for (Map.Entry<String, ReportingInstance > instanceEntry : container.getReportingInstances().entrySet()) {
                 long lastValue = 0;
-                if (lastCounterMap.containsKey(entry.getKey()))
-                	lastValue = lastCounterMap.get(entry.getKey());
-                
-                deltas.put(entry.getKey(), StatUtils.delta(lastValue, entry.getValue()));
-                lastCounterMap.put(entry.getKey(), entry.getValue());
-            }
+                String counterName = instanceEntry.getKey();
+                long currentValue = instanceEntry.getValue().count;
+                if (lastCounterMap.containsKey(counterName)) {
+                    lastValue = lastCounterMap.get(counterName);
+                    if (instanceEntry.getValue().mode == ReportingMode.DIFFERENTIAL) {
+                        deltas.put(counterName, StatUtils.delta(lastValue, currentValue));
+                    } else {
+                        deltas.put(counterName, currentValue);
+                    }
+                }
+                lastCounterMap.put(counterName, currentValue);
+           }
         }
         deltaCounterMap = deltas;
     }

--- a/pillage-core/src/main/java/com/ticketfly/pillage/StatsContainer.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/StatsContainer.java
@@ -42,6 +42,11 @@ public interface StatsContainer {
   public void incr(String name);
 
   /**
+   * Increments an integral counter by one
+   */   
+  public void incrementIntegral(String name, int increment);
+
+  /**
    * Set a label to a string.
    */
   public void set(String name, String value);
@@ -65,11 +70,13 @@ public interface StatsContainer {
    * @param name
    */
   public void clearCounter(String name);
-  
+
   /**
-   * Get the Counter object representing a named counter.
+   * Get (or create) the Counter object representing a named counter.
    */
   public Counter getCounter(String name);
+ 
+  public Counter getCounter(String name, ReportingMode mode);
 
   /**
    * Get the Metric object representing a named metric.
@@ -92,7 +99,12 @@ public interface StatsContainer {
   /**
    * evaluate all the counters in this collection.
    */
-  public Map<String,Long> counters();
+  public Map<String, Long> counters();
+
+  /**
+   * evaluate all the counters in this collection, including reporting mode.
+   */
+  public Map<String, ReportingInstance> getReportingInstances();
 
   /**
    * evaluate all the metrics in this collection.

--- a/pillage-core/src/main/java/com/ticketfly/pillage/StatsContainerImpl.java
+++ b/pillage-core/src/main/java/com/ticketfly/pillage/StatsContainerImpl.java
@@ -58,16 +58,24 @@ public class StatsContainerImpl implements StatsContainer {
 	 */
 	@Override
 	public void incr(String name, int count) {
-		getCounter(name).incr(count);
+		getCounter(name, ReportingMode.DIFFERENTIAL).incr(count);
 	}
 
 	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void incr(String name) {
-		getCounter(name).incr();
-	}
+     * {@inheritDoc}
+     */
+    @Override
+    public void incrementIntegral(String name, int increment) {
+        getCounter(name, ReportingMode.INTEGRAL).incr(increment);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void incr(String name) {
+        getCounter(name, ReportingMode.DIFFERENTIAL).incr();
+    }
 
 	/**
 	 * {@inheritDoc}
@@ -137,14 +145,27 @@ public class StatsContainerImpl implements StatsContainer {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Counter getCounter(String name) {
+	public Counter getCounter(String name, ReportingMode mode) {
 		Counter counter = counterMap.get(name);
 		if (counter == null) {
-			counterMap.putIfAbsent(name, new Counter());
+			counterMap.putIfAbsent(name, new Counter(mode));
 			counter = counterMap.get(name);
 		}
 		return counter;
 	}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Counter getCounter(String name) {
+        Counter counter = counterMap.get(name);
+        if (counter == null) {
+            counterMap.putIfAbsent(name, new Counter(ReportingMode.DIFFERENTIAL));
+            counter = counterMap.get(name);
+        }
+        return counter;
+    }
 
 	/**
 	 * {@inheritDoc}
@@ -186,6 +207,20 @@ public class StatsContainerImpl implements StatsContainer {
 		}
 		return map;
 	}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, ReportingInstance > getReportingInstances() {
+        HashMap<String, ReportingInstance> map = new HashMap<String, ReportingInstance>(counterMap.size());
+        for (Map.Entry<String, Counter> entry : counterMap.entrySet()) {
+            map.put(entry.getKey(), new ReportingInstance(entry.getValue().value(), entry.getValue().getReportingMode()));
+        }
+        return map;
+    }
+    
+    
 
 	/**
 	 * {@inheritDoc}

--- a/pillage-core/src/test/groovy/com/ticketfly/pillage/StatsCollectorImplSpec.groovy
+++ b/pillage-core/src/test/groovy/com/ticketfly/pillage/StatsCollectorImplSpec.groovy
@@ -38,13 +38,14 @@ class StatsCollectorImplSpec extends Specification {
 		given:
 			StatsContainer container = Mock()
 			container.counters() >> { [:] }
+			container.getReportingInstances() >> { [:] }
 			container.metrics() >> { [:] }
 			container.gauges() >> { [:] }
 			def collector = new StatsCollectorImpl(container)
 		when:
 			collector.collect()
 		then:
-			1 * container.counters() >> { [:] }
+			1 * container.getReportingInstances() >> { [:] }
 			1 * container.metrics() >> { [:] }
 	}
 	
@@ -64,6 +65,7 @@ class StatsCollectorImplSpec extends Specification {
 		given:
 			StatsContainer container = Mock()
 			container.counters() >> { [:] }
+			container.getReportingInstances() >> { [:] }
 			container.metrics() >> { [:] }
 			container.gauges() >> { [:] }
 			container.getSummary() >> { new StatsSummary([:], [:], [:]) }
@@ -80,6 +82,7 @@ class StatsCollectorImplSpec extends Specification {
 		given:
 			StatsContainer container = Mock()
 			container.counters() >> { [:] }
+			container.getReportingInstances() >> { [:] }
 			container.metrics() >> { [:] }
 			container.gauges() >> { [:] }
 			container.getSummary() >> { new StatsSummary([:], [:], [:]) }


### PR DESCRIPTION
This add the capability of returning counters to graphite or other reporters which contain integral values rather than differential ones. It is a backward compatible change, in that it does not change the default behavior (which is differential reporting), and adds a stats API rather than changing an existing API.
